### PR TITLE
Allow setting custom user-agents on electron webviews

### DIFF
--- a/electron/src/index.ts
+++ b/electron/src/index.ts
@@ -23,12 +23,12 @@ export class WebviewController extends EventEmitter implements WebviewController
     const mainSession = this.window.webContents.session;
 
     const customCSP = "script-src 'self' 'unsafe-inline' 'unsafe-eval' *; style-src 'self' 'unsafe-inline' *;";
-    if (typeof options.userAgent !== "undefined") {
-      mainSession.webRequest.onBeforeSendHeaders((details, callback) => {
-        details.requestHeaders['User-Agent'] = options.userAgent ?? "";
-        callback({ cancel: false, requestHeaders: details.requestHeaders });
-      });
-    }
+
+    mainSession.webRequest.onBeforeSendHeaders((details, callback) => {
+      details.requestHeaders['User-Agent'] = options.userAgent ?? details.requestHeaders['User-Agent']
+      callback({ cancel: false, requestHeaders: details.requestHeaders });
+    });
+
     mainSession.webRequest.onHeadersReceived((details, callback) => {
       const responseHeaders = Object.assign({}, details.responseHeaders, {
         'Content-Security-Policy': customCSP,

--- a/electron/src/index.ts
+++ b/electron/src/index.ts
@@ -23,9 +23,9 @@ export class WebviewController extends EventEmitter implements WebviewController
     const mainSession = this.window.webContents.session;
 
     const customCSP = "script-src 'self' 'unsafe-inline' 'unsafe-eval' *; style-src 'self' 'unsafe-inline' *;";
-    if (typeof userAgent !== "undefined"){
-      session.defaultSession.webRequest.onBeforeSendHeaders((details, callback) => {
-        details.requestHeaders['User-Agent'] = userAgent;
+    if (typeof options.userAgent !== "undefined") {
+      mainSession.webRequest.onBeforeSendHeaders((details, callback) => {
+        details.requestHeaders['User-Agent'] = options.userAgent ?? "";
         callback({ cancel: false, requestHeaders: details.requestHeaders });
       });
     }
@@ -36,7 +36,7 @@ export class WebviewController extends EventEmitter implements WebviewController
       callback({ cancel: false, responseHeaders });
     });
 
-    this.window.loadURL(options.url, 
+    this.window.loadURL(options.url);
     return Promise.resolve()
   }
   closeWindow(): Promise<void> {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "capacitor-webview-controller",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "capacitor-webview-controller",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "license": "MIT",
       "dependencies": {
         "electron": "^26.2.2"


### PR DESCRIPTION
This PR allows passing custom user-agent headers through to the electron webview.

Tested on macOS 12 on ARM.
